### PR TITLE
Depend on earlier version of redis-rack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 gemspec
 
 if ::File.directory?(gem_path = '../redis-store')
-  gem 'redis-store', '~> 1.2.0.pre', path: gem_path
+  gem 'redis-store', '~> 1.2.0', path: gem_path
 end
 
 if ::File.directory?(gem_path = '../redis-rack')
-  gem 'redis-rack', '~> 2.0.0.pre', path: gem_path
+  gem 'redis-rack', '~> 1', path: gem_path
 end

--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'redis-store', '~> 1.2.0.pre'
-  s.add_runtime_dependency 'redis-rack',  '~> 2.0.0.pre'
+  s.add_runtime_dependency 'redis-store', '~> 1.2.0'
+  s.add_runtime_dependency 'redis-rack',  '~> 1'
   s.add_runtime_dependency 'actionpack',  '>= 4.0.0', '< 6'
 
   s.add_development_dependency 'rake',     '~> 10'

--- a/test/redis/actionpack/version_test.rb
+++ b/test/redis/actionpack/version_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-describe Redis::ActionPack::VERSION do
-  it 'returns current version' do
-    Redis::ActionPack::VERSION.must_equal '4.0.1'
-  end
-end


### PR DESCRIPTION
redis-rack needs rack 2.0, which is currently not being supported by
the latest rails 5.x actionpack. We'll use the latest 1.6.x until Rails
supports Rack 2.0. This should resolve #11 and #10.