### PR TITLE
Add ability to set session ID cookie as secure and httponly

### DIFF
--- a/lib/action_dispatch/middleware/session/redis_store.rb
+++ b/lib/action_dispatch/middleware/session/redis_store.rb
@@ -18,13 +18,16 @@ module ActionDispatch
       private
 
       def set_cookie(env, session_id, cookie)
-
         if env.is_a? ActionDispatch::Request
           request = env
         else
           request = ActionDispatch::Request.new(env)
         end
-        request.cookie_jar[key] = cookie
+        request.cookie_jar[key] = cookie.merge(cookie_options)
+      end
+
+      def cookie_options
+        @default_options.slice(:httponly, :secure)
       end
     end
   end

--- a/test/integration/redis_store_integration_test.rb
+++ b/test/integration/redis_store_integration_test.rb
@@ -43,6 +43,56 @@ class RedisStoreIntegrationTest < ::ActionDispatch::IntegrationTest
     end
   end
 
+  test "should set a non-secure cookie by default" do
+    with_test_route_set do
+      https!
+
+      get '/set_session_value'
+      assert_response :success
+
+      cookie = cookies.instance_variable_get('@cookies').first
+
+      assert !cookie.secure?
+    end
+  end
+
+  test "should set a secure cookie when the 'secure' option is set" do
+    with_test_route_set(secure: true) do
+      https!
+
+      get '/set_session_value'
+      assert_response :success
+
+      cookie = cookies.instance_variable_get('@cookies').first
+
+      assert cookie.secure?
+    end
+  end
+
+  test "should set a http-only cookie by default" do
+    with_test_route_set do
+      get '/set_session_value'
+      assert_response :success
+
+      cookie = cookies.instance_variable_get('@cookies').first
+      options = cookie.instance_variable_get('@options')
+
+      assert options.key?('HttpOnly')
+    end
+  end
+
+  test "should set a non-http-only cookie when the 'httponlty' option is set to false" do
+    with_test_route_set(httponly: false) do
+      get '/set_session_value'
+      assert_response :success
+
+      cookie = cookies.instance_variable_get('@cookies').first
+      options = cookie.instance_variable_get('@options')
+
+      assert !options.key?('HttpOnly')
+    end
+  end
+
   test "should not send cookies on write, not read" do
     with_test_route_set do
       get '/get_session_value'


### PR DESCRIPTION
We use redis-rails to provide a redis-backed session store for our rails app. Firstly - thanks for your great work! 

It's now a requirement for us to set all our cookies to be secure and httponly. I couldn't see how to do this using this gem's existing configuration options. This PR would ensure that configuring a redis session store with :secure and :httponly options passes those options to the session cookie:

```
# config/environments/production.rb
config.session_store :redis_store, secure: true, httponly: true
```

I haven't added any tests - I struggled a little with setting up integration test assertions here - so I understand this code may not be suitable in its current form. I'd be interested to hear your thoughts.