### PR TITLE
Fixed issue with incompatible same-site: none browsers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gem "mocha", "~> 0.14.0"
 gem "minitest-rails", "~> 6.0"
 gem "tzinfo", "~> 1.2"
 gem "appraisal", "~> 2.2"
+gem "should_send_same_site_none", "~> 0.1"
 gem "redis-store-testing", github: 'redis-store/testing', branch: 'v0.0.3'

--- a/lib/action_dispatch/middleware/session/redis_store.rb
+++ b/lib/action_dispatch/middleware/session/redis_store.rb
@@ -31,10 +31,9 @@ module ActionDispatch
           if (cookie[:same_site].present? && cookie[:same_site] == :none)
             cookie.delete(:same_site)
           end
-          cookie_jar(request)[key] = cookie.merge(cookie_options)
-        else
-          cookie_jar(request)[key] = cookie.merge(cookie_options)
         end
+
+        cookie_jar(request)[key] = cookie.merge(cookie_options)
       end
 
       def get_cookie(request)

--- a/lib/action_dispatch/middleware/session/redis_store.rb
+++ b/lib/action_dispatch/middleware/session/redis_store.rb
@@ -26,7 +26,14 @@ module ActionDispatch
 
       def set_cookie(env, _session_id, cookie)
         request = wrap_in_request(env)
-        cookie_jar(request)[key] = cookie.merge(cookie_options)
+        if (request.user_agent.present? && !ShouldSendSameSiteNone.is_same_site_compatible(request.user_agent))
+          if (cookie[:same_site].present? && cookie[:same_site] == :none)
+            cookie.delete(:same_site)
+          end
+          cookie_jar(request)[key] = cookie.merge(cookie_options)
+        else
+          cookie_jar(request)[key] = cookie.merge(cookie_options)
+        end
       end
 
       def get_cookie(request)

--- a/lib/action_dispatch/middleware/session/redis_store.rb
+++ b/lib/action_dispatch/middleware/session/redis_store.rb
@@ -2,6 +2,7 @@
 
 require 'redis-store'
 require 'redis-rack'
+require 'should_send_same_site_none'
 require 'action_dispatch/middleware/session/abstract_store'
 
 module ActionDispatch

--- a/lib/redis-actionpack.rb
+++ b/lib/redis-actionpack.rb
@@ -1,4 +1,5 @@
 require 'redis-store'
+require 'should_send_same_site_none'
 require 'action_pack'
 require 'redis/actionpack/version'
 require 'action_dispatch/middleware/session/redis_store'

--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'redis-store', '>= 1.1.0', '< 2'
   s.add_runtime_dependency 'redis-rack',  '>= 2.1.0', '< 3'
   s.add_runtime_dependency 'actionpack',  '>= 5', '< 7'
+  s.add_runtime_dependency 'should_send_same_site_none', '>= 0.1', '< 0.5'
 end

--- a/test/integration/redis_store_integration_test.rb
+++ b/test/integration/redis_store_integration_test.rb
@@ -56,6 +56,30 @@ class RedisStoreIntegrationTest < ::ActionDispatch::IntegrationTest
     end
   end
 
+  test "shouldn't remove a same_site: none cookie when the user_agent is compatible" do
+    with_test_route_set(same_site: :none) do
+      https!
+
+      get '/set_session_value', headers: { "User-Agent": 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36' }
+      assert_response :success
+
+      cookie = cookies.instance_variable_get('@cookies').first
+      assert cookie.instance_variable_get('@options')["SameSite"].present?
+    end
+  end
+
+  test "MUST remove a same_site: none cookie when the user_agent isn't compatible" do
+    with_test_route_set(same_site: :none) do
+      https!
+
+      get '/set_session_value', headers: { "User-Agent": 'Mozilla/5.0 doogiePIM/1.0.4.2 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36' }
+      assert_response :success
+
+      cookie = cookies.instance_variable_get('@cookies').first
+      assert cookie.instance_variable_get('@options')["SameSite"].nil?
+    end
+  end
+
   test "should set a secure cookie when the 'secure' option is set" do
     with_test_route_set(secure: true) do
       https!


### PR DESCRIPTION
We were using `same-site: :none`, and `secure: true` on our session_store, but we found issues in some browsers, after some research we found:

- Versions of Chrome from Chrome 51 to Chrome 66 (inclusive on both ends) are affected
- Versions of UC Browser on Android prior to version 12.13.2
- Versions of Safari and embedded browsers on MacOS 10.14 and all browsers on iOS 12

All of them are checked on the dependency that i've installed, so when a request is coming if the user agent is not compatible, we remove the same_site cookie.

I'm not an expert ruby developer so i'm open to criticism. 

### Links
- https://www.chromium.org/updates/same-site/incompatible-clients