### PR TITLE
Bump `actionpack` support version to 7.X

### DIFF
--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis-store', '>= 1.1.0', '< 2'
   s.add_runtime_dependency 'redis-rack',  '>= 2.1.0', '< 3'
-  s.add_runtime_dependency 'actionpack',  '>= 5', '< 7'
+  s.add_runtime_dependency 'actionpack',  '>= 5', '< 8'
 end


### PR DESCRIPTION
This change corresponds to the recently released `rails` version 7.X.

https://github.com/rails/rails/blob/7-0-stable/actionpack/CHANGELOG.md#rails-700-december-15-2021


```
In Gemfile:
  rails (= 7.0.0) was resolved to 7.0.0, which depends on
    actionpack (= 7.0.0)

  redis-actionpack was resolved to 5.2.0, which depends on
    actionpack (>= 5, < 7)
```

I referred to PR https: //github.com/redis-store/redis-actionpack/pull/25.
Therefore, the version specification is specified so that all 7 series support it.

FYI
Similarly redis-activesupport I also changed.
https://github.com/redis-store/redis-activesupport/pull/130
