### PR TITLE
Update gemspec to contain source code url

### DIFF
--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -11,6 +11,9 @@ Gem::Specification.new do |s|
   s.summary     = %q{Redis session store for ActionPack}
   s.description = "#{s.summary}. Used for storing the Rails session in Redis."
   s.license     = 'MIT'
+  s.metadata    = {
+    "source_code_uri" => "https://github.com/redis-store/redis-actionpack"
+  }
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
It's done in order to correctly display the link on the RubyGems page