### PR TITLE
Remove actionpack upper version constraint

### DIFF
--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis-store', '>= 1.1.0', '< 2'
   s.add_runtime_dependency 'redis-rack',  '>= 2.1.0', '< 4'
-  s.add_runtime_dependency 'actionpack',  '>= 5', '< 8'
+  s.add_runtime_dependency 'actionpack',  '>= 5'
 end


### PR DESCRIPTION
## why
Rails v8.0.0 released. So we upgrade our open source rails app.

* https://github.com/kaigionrails/conference-app/pull/374

But redis-actionpack's gemspec sets actionpack version constraint to `< 8`, so bundler removes redis-actionpack gem from our app.

see https://github.com/kaigionrails/conference-app/pull/374/commits/36405a2eebb23b4f892ec54208acb60c76a2aadc#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fL365-R365

## what
Remove actionpack upper version constraint from gemspec.