### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/redis-actionpack

### DIFF
--- a/redis-actionpack.gemspec
+++ b/redis-actionpack.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.description = "#{s.summary}. Used for storing the Rails session in Redis."
   s.license     = 'MIT'
   s.metadata    = {
+    'changelog_uri' => 'https://github.com/redis-store/redis-actionpack/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/redis-store/redis-actionpack'
   }
 


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/redis-actionpack which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata